### PR TITLE
feat: PHP 8 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,9 +8,6 @@ jobs:
     strategy:
       matrix:
         php: ["7.4", "8.0"]
-        include:
-          - php: "8.0"
-            composer_args: "--ignore-platform-reqs"
 
     runs-on: ubuntu-latest
     container:
@@ -36,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --no-progress --no-interaction ${{ matrix.composer_args }} > /dev/null
+          composer update --no-progress --no-interaction > /dev/null
 
       - name: PHPCS
         if: matrix.php != '8.0'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,20 +1,20 @@
 name: Check Build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
 
     strategy:
       matrix:
-        php: ["7.4"]
+        php: ["7.4", "8.0"]
+        include:
+          - php: "8.0"
+            composer_args: "--ignore-platform-reqs"
 
     runs-on: ubuntu-latest
     container:
       image: eventjet/checks-${{ matrix.php }}:latest
-
-    env:
-      COMPOSER_ARGS: ''
 
     steps:
       - name: Checkout
@@ -24,29 +24,28 @@ jobs:
         run: |
           mkdir -p /root/.ssh
           ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
-
-      - name: Ignore Plaform Reqs if on PHP8
-        if: ${{ matrix.php == '8.0' }}
-        run: |
-          echo "COMPOSER_ARGS=--ignore-platform-reqs" >> $GITHUB_ENV
-          composer self-update --2
+          echo "COMPOSER_CACHE=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Composer Cache
         uses: actions/cache@v2
         with:
-          path: $(composer config cache-files-dir)
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
+          path: |
+            ${{ env.COMPOSER_CACHE }}
+            vendor
+          key: ${{ runner.os }}-composer
 
       - name: Install dependencies
         run: |
-          composer install --no-progress --no-suggest --no-interaction ${{ env.COMPOSER_ARGS }} > /dev/null
+          composer update --no-progress --no-interaction ${{ matrix.composer_args }} > /dev/null
+
+      - name: PHPCS
+        if: matrix.php != '8.0'
+        run: |
+          composer cs-check
 
       - name: Static analysis
         run: |
           composer check-deps
-          composer cs-check
           composer phpstan -- --no-progress
 
       - name: Tests
@@ -60,5 +59,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           clover_file: "coverage.xml"
-          threshold_alert: 99
-          threshold_warning: 99
+          comment_context: PHP ${{ matrix.php }}
+          threshold_alert: 100
+          threshold_warning: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.0.0 - TBD
+
+### BC Breaks
+
+- PHP 8.0 deprecates required parameters after optional parameters and to avoid a deprecation notice in PHP 8, the
+  signature of `PermissionServiceInterface` had to be changed to
+  `public function isAllowed($user, string $permission, $resource = null): bool`
+  Also, a return type was added.
+- Return type added to `PermissionInterface`
+
+### Added
+
+- [#5](https://github.com/MidnightDesign/midnight-permissions/pull/5) adds support for PHP 8
+
+### Changed
+
+- [#5](https://github.com/MidnightDesign/midnight-permissions/pull/5) changes method signature
+  of `PermissionServiceInterface`
+- [#5](https://github.com/MidnightDesign/midnight-permissions/pull/5) adds a return type to `PermissionInterface`
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.2.0 - 2020-12-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,31 +12,31 @@ Install `midnight/permissions` via Composer.
 
 ## Usage
 
-You need a [Container](https://github.com/container-interop/container-interop) that can provide your `PermissionService`
-with permissions. In this example, we're going to use `league/container`, but any container implementing 
-`Interop\Container\ContainerInterface` will work.
+You need a [Container](https://github.com/php-fig/container) that can provide your `PermissionService`
+with permissions. In this example, we're going to use `league/container`, but any container implementing
+`Psr\Container\ContainerInterface` will work.
 
 For brevity, the user and resource are arrays in this example. Most likely, they will be objects any real-world project.
 
 ```php
 class CanDoSomething implements Midnight\Permissions\PermissionInterface
 {
-    public function isAllowed($user = null, $resource = null) {
+    public function isAllowed($user = null, $resource = null): bool {
         return $user === $resource['owner'];
     }
 }
 
-$container = new League\Container\Container;
+$container = new League\Container\Container();
 $container->add('can_do_something', CanDoSomething::class);
 
-$permissionService = new Midnight\PermissionService\PermissionService($container);
+$permissionService = new Midnight\Permissions\PermissionService($container);
 
 $permissionService->isAllowed('Rudolph', 'can_do_something', ['owner' => 'Rudolph']); // true
 $permissionService->isAllowed('Rudolph', 'can_do_something', ['owner' => 'Christoph']); // false
 ```
 
-## Zend Framework 2 Module
+## Laminas Module
 
-There's also a ZF2 module that will let you access the `PermissionService` via the Service Manager, add permissions via 
-the config and give you view helpers and controller plugins. It's called 
+There's also a Laminas module that will let you access the `PermissionService` via the Service Manager, add permissions
+via the config and give you view helpers and controller plugins. It's called
 [midnight/permissions-module](https://github.com/MidnightDesign/midnight-permissions-module).

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.4",
-        "psr/container": "^1.0"
+        "php": "^7.4 || ^8.0",
+        "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
         "eventjet/coding-standard": "^3.2",
-        "infection/infection": "^0.20.0",
-        "maglnet/composer-require-checker": "^2.1",
+        "infection/infection": "^0.22.1",
+        "maglnet/composer-require-checker": "^3.2",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.32",
         "phpstan/phpstan-phpunit": "^0.12.16",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="Eventjet coding standard">
     <rule ref="EventjetStrict"/>
+
+    <arg name="parallel" value="80"/>
+
     <file>src</file>
     <file>tests</file>
 

--- a/src/PermissionInterface.php
+++ b/src/PermissionInterface.php
@@ -9,7 +9,6 @@ interface PermissionInterface
     /**
      * @param mixed|null $user
      * @param mixed|null $resource
-     * @return bool
      */
-    public function isAllowed($user = null, $resource = null);
+    public function isAllowed($user = null, $resource = null): bool;
 }

--- a/src/PermissionService.php
+++ b/src/PermissionService.php
@@ -28,7 +28,7 @@ final class PermissionService implements PermissionServiceInterface
      * @throws UnknownPermissionException
      * @throws InvalidPermissionException
      */
-    public function isAllowed($user = null, string $permission, $resource = null): bool
+    public function isAllowed($user, string $permission, $resource = null): bool
     {
         if (!$this->container->has($permission)) {
             throw new UnknownPermissionException(sprintf('Unknown permission %s.', $permission));

--- a/src/PermissionServiceInterface.php
+++ b/src/PermissionServiceInterface.php
@@ -9,7 +9,6 @@ interface PermissionServiceInterface
     /**
      * @param mixed|null $user
      * @param mixed|null $resource
-     * @return bool
      */
-    public function isAllowed($user = null, string $permission, $resource = null);
+    public function isAllowed($user, string $permission, $resource = null): bool;
 }

--- a/src/PermissionServiceStub.php
+++ b/src/PermissionServiceStub.php
@@ -12,7 +12,7 @@ final class PermissionServiceStub implements PermissionServiceInterface
      * @param mixed|null $user
      * @param mixed|null $resource
      */
-    public function isAllowed($user = null, string $permission, $resource = null): bool
+    public function isAllowed($user, string $permission, $resource = null): bool
     {
         return $this->isAllowed;
     }


### PR DESCRIPTION
BC-Break: To avoid deprecation notices in PHP8 the signature of `PermissionServiceInterface` was changed.
Return types were added to `PermissionServiceInterface` and `PermissionInterface`.